### PR TITLE
Move versioneer's _version.py to base directory

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,1 @@
-cyminmax/_version.py export-subst
+_version.py export-subst

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -10,4 +10,4 @@ recursive-exclude * *.py[co]
 recursive-include docs *.rst conf.py Makefile make.bat *.jpg *.png *.gif
 
 include versioneer.py
-include cyminmax/_version.py
+include _version.py

--- a/_version.py
+++ b/_version.py
@@ -43,7 +43,7 @@ def get_config():
     cfg.style = "pep440"
     cfg.tag_prefix = "v"
     cfg.parentdir_prefix = "cyminmax"
-    cfg.versionfile_source = "cyminmax/_version.py"
+    cfg.versionfile_source = "_version.py"
     cfg.verbose = False
     return cfg
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,8 +1,8 @@
 [versioneer]
 VCS = git
 style = pep440
-versionfile_source = cyminmax/_version.py
-versionfile_build = cyminmax/_version.py
+versionfile_source = _version.py
+versionfile_build = _version.py
 tag_prefix = v
 parentdir_prefix = cyminmax
 

--- a/setup.py
+++ b/setup.py
@@ -6,6 +6,7 @@ import sys
 import setuptools
 from setuptools import setup
 from setuptools.command.test import test as TestCommand
+
 import versioneer
 
 


### PR DESCRIPTION
Adjust the location of `_version.py` as `cyminmax` is about to be replaced with `src`, which will contain any Cython and/or Python source code as needed. Also run `versioneer install` to make sure that nothing was missed in the process.