### PR TITLE
Make Cython stub

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,6 +1,7 @@
 [run]
 branch = True
 source = cyminmax
+plugins = Cython.Coverage
 [report]
 exclude_lines =
     # Include the no cover pragma as it needs to be listed explicitly when

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,1 @@
-cyminmax/_version.py export-subst
+_version.py export-subst

--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@ __pycache__/
 # C extensions
 *.so
 src/cyminmax.c
+src/version.pxi
 
 # Distribution / packaging
 .Python

--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@ __pycache__/
 
 # C extensions
 *.so
+src/cyminmax.c
 
 # Distribution / packaging
 .Python

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -10,4 +10,4 @@ recursive-exclude * *.py[co]
 recursive-include docs *.rst conf.py Makefile make.bat *.jpg *.png *.gif
 
 include versioneer.py
-include cyminmax/_version.py
+include _version.py

--- a/_version.py
+++ b/_version.py
@@ -43,7 +43,7 @@ def get_config():
     cfg.style = "pep440"
     cfg.tag_prefix = "v"
     cfg.parentdir_prefix = "cyminmax"
-    cfg.versionfile_source = "cyminmax/_version.py"
+    cfg.versionfile_source = "_version.py"
     cfg.verbose = False
     return cfg
 

--- a/cyminmax/__init__.py
+++ b/cyminmax/__init__.py
@@ -1,8 +1,0 @@
-# -*- coding: utf-8 -*-
-
-__author__ = """John Kirkham"""
-__email__ = "kirkhamj@janelia.hhmi.org"
-
-from ._version import get_versions
-__version__ = get_versions()['version']
-del get_versions

--- a/environment_ci.yml
+++ b/environment_ci.yml
@@ -8,3 +8,4 @@ dependencies:
   - wheel==0.29.0
   - coverage==4.4.2
   - pytest==3.0.5
+  - cython==0.25.2

--- a/environment_doc.yml
+++ b/environment_doc.yml
@@ -7,3 +7,4 @@ dependencies:
   - pip==9.0.1
   - wheel==0.29.0
   - Sphinx==1.5.1
+  - cython==0.25.2

--- a/environment_dpl.yml
+++ b/environment_dpl.yml
@@ -8,5 +8,6 @@ dependencies:
   - wheel==0.29.0
   - coverage==4.0.3
   - python-coveralls==2.7.0
+  - cython==0.25.2
   - cryptography==1.4
   - pyyaml==3.11

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,8 +1,8 @@
 [versioneer]
 VCS = git
 style = pep440
-versionfile_source = cyminmax/_version.py
-versionfile_build = cyminmax/_version.py
+versionfile_source = _version.py
+versionfile_build = _version.py
 tag_prefix = v
 parentdir_prefix = cyminmax
 

--- a/setup.py
+++ b/setup.py
@@ -27,7 +27,7 @@ with open("README.rst") as readme_file:
     readme = readme_file.read()
 
 setup_requirements = [
-    # TODO: put package build requirements here
+    "cython>=0.25.2",
 ]
 
 install_requirements = [

--- a/setup.py
+++ b/setup.py
@@ -63,6 +63,13 @@ else:
         ])
 
 
+try:
+    i = sys.argv.index("test")
+    sys.argv = sys.argv[:i] + ["build_ext", "--inplace"] + sys.argv[i:]
+except ValueError:
+    pass
+
+
 include_dirs = [
     os.path.dirname(get_python_inc()),
     get_python_inc()

--- a/setup.py
+++ b/setup.py
@@ -6,6 +6,7 @@ import sys
 import setuptools
 from setuptools import setup
 from setuptools.command.test import test as TestCommand
+
 import versioneer
 
 

--- a/setup.py
+++ b/setup.py
@@ -1,11 +1,15 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
+import os
 import sys
+from glob import glob
 
 import setuptools
-from setuptools import setup
+from setuptools import setup, Extension
 from setuptools.command.test import test as TestCommand
+
+from distutils.sysconfig import get_config_var, get_python_inc
 
 import versioneer
 
@@ -50,6 +54,23 @@ if not (({"develop", "test"} & set(sys.argv)) or
     any([v.startswith("install") for v in sys.argv])):
     setup_requirements = []
 
+
+include_dirs = [
+    os.path.dirname(get_python_inc()),
+    get_python_inc()
+]
+library_dirs = list(filter(
+    lambda v: v is not None,
+    [get_config_var("LIBDIR")]
+))
+
+headers = []
+sources = glob("src/*.pxd") + glob("src/*.pyx")
+libraries = []
+define_macros = []
+extra_compile_args = []
+
+
 setup(
     name="cyminmax",
     version=versioneer.get_version(),
@@ -63,6 +84,19 @@ setup(
     include_package_data=True,
     setup_requires=setup_requirements,
     install_requires=install_requirements,
+    headers=headers,
+    ext_modules=[
+        Extension(
+            "cyminmax",
+            sources=sources,
+            include_dirs=include_dirs,
+            library_dirs=library_dirs,
+            libraries=libraries,
+            define_macros=define_macros,
+            extra_compile_args=extra_compile_args,
+            language="c"
+        )
+    ],
     license="BSD 3-Clause",
     zip_safe=False,
     keywords="cyminmax",

--- a/setup.py
+++ b/setup.py
@@ -27,8 +27,11 @@ class PyTest(TestCommand):
         sys.exit(pytest.main(self.test_args))
 
 
+version = versioneer.get_version()
+
 with open("README.rst") as readme_file:
     readme = readme_file.read()
+
 
 setup_requirements = [
     "cython>=0.25.2",
@@ -53,6 +56,11 @@ if not (({"develop", "test"} & set(sys.argv)) or
     any([v.startswith("bdist") for v in sys.argv]) or
     any([v.startswith("install") for v in sys.argv])):
     setup_requirements = []
+else:
+    with open("src/version.pxi", "w") as f:
+        f.writelines([
+            "__version__ = " + "\"" + str(version) + "\""
+        ])
 
 
 include_dirs = [
@@ -92,7 +100,7 @@ for em in ext_modules:
 
 setup(
     name="cyminmax",
-    version=versioneer.get_version(),
+    version=version,
     description="A minmax implementation in Cython for use with NumPy",
     long_description=readme,
     author="John Kirkham",

--- a/setup.py
+++ b/setup.py
@@ -88,6 +88,18 @@ cython_directives = {}
 cython_line_directives = {}
 
 
+if "test" in sys.argv:
+    cython_directives["binding"] = True
+    cython_directives["embedsignature"] = True
+    cython_directives["profile"] = True
+    cython_directives["linetrace"] = True
+    define_macros += [
+        ("CYTHON_PROFILE", 1),
+        ("CYTHON_TRACE", 1),
+        ("CYTHON_TRACE_NOGIL", 1),
+    ]
+
+
 ext_modules = [
     Extension(
         "cyminmax",

--- a/setup.py
+++ b/setup.py
@@ -69,6 +69,25 @@ sources = glob("src/*.pxd") + glob("src/*.pyx")
 libraries = []
 define_macros = []
 extra_compile_args = []
+cython_directives = {}
+cython_line_directives = {}
+
+
+ext_modules = [
+    Extension(
+        "cyminmax",
+        sources=sources,
+        include_dirs=include_dirs,
+        library_dirs=library_dirs,
+        libraries=libraries,
+        define_macros=define_macros,
+        extra_compile_args=extra_compile_args,
+        language="c"
+    )
+]
+for em in ext_modules:
+    em.cython_directives = dict(cython_directives)
+    em.cython_line_directives = dict(cython_line_directives)
 
 
 setup(
@@ -85,18 +104,7 @@ setup(
     setup_requires=setup_requirements,
     install_requires=install_requirements,
     headers=headers,
-    ext_modules=[
-        Extension(
-            "cyminmax",
-            sources=sources,
-            include_dirs=include_dirs,
-            library_dirs=library_dirs,
-            libraries=libraries,
-            define_macros=define_macros,
-            extra_compile_args=extra_compile_args,
-            language="c"
-        )
-    ],
+    ext_modules=ext_modules,
     license="BSD 3-Clause",
     zip_safe=False,
     keywords="cyminmax",

--- a/src/cyminmax.pyx
+++ b/src/cyminmax.pyx
@@ -1,0 +1,1 @@
+cimport cyminmax

--- a/src/cyminmax.pyx
+++ b/src/cyminmax.pyx
@@ -1,1 +1,3 @@
 cimport cyminmax
+
+include "version.pxi"


### PR DESCRIPTION
Redesigns the package layout to allow for a single Cython module to be built and tested. Adjusts versioneer's file locations to workaround these constraints. Also embeds the version information in the resultant Cython module.