### PR TITLE
Use setup requires in more cases

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -43,8 +43,10 @@ cmdclasses = {
 cmdclasses.update(versioneer.get_cmdclass())
 
 
-if not ({"build", "install"}.intersection(sys.argv) or
-    any([v.startswith("bdist") for v in sys.argv])):
+if not (({"develop", "test"} & set(sys.argv)) or
+    any([v.startswith("build") for v in sys.argv]) or
+    any([v.startswith("bdist") for v in sys.argv]) or
+    any([v.startswith("install") for v in sys.argv])):
     setup_requirements = []
 
 setup(


### PR DESCRIPTION
The setup requirements are still needed in many others cases as a build may still need to occur. These include many variants of the `build`, `bdist`, and `install` commands. Also make sure that `develop` and `test` are checked as well since these may require a build to occur too.