### PR TITLE
Drop `python-coveralls` from CI requirements

### DIFF
--- a/environment_ci.yml
+++ b/environment_ci.yml
@@ -7,5 +7,4 @@ dependencies:
   - pip==9.0.1
   - wheel==0.29.0
   - coverage==4.0.3
-  - python-coveralls==2.7.0
   - pytest==3.0.5


### PR DESCRIPTION
As `python-coveralls` is not required for the CI build and test phases, drop it from `environment_ci.yml`. It gets pulled in during the deployment phase with `environment_dpl.yml` when it is actually needed anyways.