### PR TITLE
Print version on Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -36,7 +36,8 @@ install:
 # command to run tests, e.g. python setup.py test
 script:
   - coverage erase
-  - coverage run --source . setup.py test
+  - coverage run --append --source . setup.py --version
+  - coverage run --append --source . setup.py test
   - coverage report -m
 
 # Report coverage


### PR DESCRIPTION
Should test that setup requirements are dropped for this case. Also provides the version information in the log, which is nice too.