### PR TITLE
Drop pip install on CIs

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -84,9 +84,6 @@ install:
 build: off
 
 test_script:
-    # Install the package and dependencies.
-    - cmd: pip install -e .
-
     # command to run tests, e.g. python setup.py test
     - cmd: coverage erase
     - cmd: coverage run --append --source . setup.py --version

--- a/.travis.yml
+++ b/.travis.yml
@@ -30,9 +30,6 @@ install:
   - conda list --full-name -n testenv openssl || conda install -y -n testenv openssl
   - source activate testenv
 
-  # Install the package and dependencies.
-  - pip install -e .
-
 # command to run tests, e.g. python setup.py test
 script:
   - coverage erase


### PR DESCRIPTION
Installing this library with `pip` is not necessary as the test phase will already handle these build and install steps. Also the dependencies are already added to the environment. So just drop the `pip install` step for simplicity.