### PR TITLE
Require coverage 4.4.2

### DIFF
--- a/environment_ci.yml
+++ b/environment_ci.yml
@@ -6,5 +6,5 @@ channels:
 dependencies:
   - pip==9.0.1
   - wheel==0.29.0
-  - coverage==4.0.3
+  - coverage==4.4.2
   - pytest==3.0.5


### PR DESCRIPTION
Partially resolves issue ( https://github.com/jakirkham/cyminmax/issues/9 ).

This should fix a bug that we are experiencing with `coverage` version `4.0.3`. Namely was having some issues running `python setup.py --version` and including it in the coverage.