### PR TITLE
Install library on Read the Docs

### DIFF
--- a/readthedocs.yml
+++ b/readthedocs.yml
@@ -1,2 +1,4 @@
 conda:
   file: environment_doc.yml
+python:
+  setup_py_install: true


### PR DESCRIPTION
Needed to ensure the Cython module is compiled and importable. This is important for Sphinx to be able to discover the function docstrings for use in the API docs.