### PR TITLE
Add build_ext derived command class to aid building with NumPy

### DIFF
--- a/environment_ci.yml
+++ b/environment_ci.yml
@@ -9,4 +9,4 @@ dependencies:
   - coverage==4.4.2
   - pytest==3.0.5
   - cython==0.25.2
-  - numpy==1.8.2
+  - numpy==1.11.3

--- a/environment_ci.yml
+++ b/environment_ci.yml
@@ -9,3 +9,4 @@ dependencies:
   - coverage==4.4.2
   - pytest==3.0.5
   - cython==0.25.2
+  - numpy==1.8.2

--- a/environment_doc.yml
+++ b/environment_doc.yml
@@ -8,4 +8,4 @@ dependencies:
   - wheel==0.29.0
   - Sphinx==1.5.1
   - cython==0.25.2
-  - numpy==1.8.2
+  - numpy==1.11.3

--- a/environment_doc.yml
+++ b/environment_doc.yml
@@ -8,3 +8,4 @@ dependencies:
   - wheel==0.29.0
   - Sphinx==1.5.1
   - cython==0.25.2
+  - numpy==1.8.2

--- a/setup.py
+++ b/setup.py
@@ -45,10 +45,9 @@ test_requirements = [
     "pytest",
 ]
 
-cmdclasses = {
-    "test": PyTest,
-}
+cmdclasses = dict()
 cmdclasses.update(versioneer.get_cmdclass())
+cmdclasses["test"] = PyTest
 
 
 if not (({"develop", "test"} & set(sys.argv)) or

--- a/setup.py
+++ b/setup.py
@@ -7,11 +7,21 @@ from glob import glob
 
 import setuptools
 from setuptools import setup, Extension
+from setuptools.command.build_ext import build_ext as BuildExtCommand
 from setuptools.command.test import test as TestCommand
 
 from distutils.sysconfig import get_config_var, get_python_inc
 
 import versioneer
+
+
+class NumPyBuildExt(BuildExtCommand):
+    def finalize_options(self):
+        BuildExtCommand.finalize_options(self)
+        # Prevent numpy from thinking it is still in its setup process:
+        __builtins__.__NUMPY_SETUP__ = False
+        import numpy
+        self.include_dirs.append(numpy.get_include())
 
 
 class PyTest(TestCommand):
@@ -48,6 +58,7 @@ test_requirements = [
 
 cmdclasses = dict()
 cmdclasses.update(versioneer.get_cmdclass())
+cmdclasses["build_ext"] = NumPyBuildExt
 cmdclasses["test"] = PyTest
 
 

--- a/setup.py
+++ b/setup.py
@@ -45,7 +45,7 @@ with open("README.rst") as readme_file:
 
 setup_requirements = [
     "cython>=0.25.2",
-    "numpy>=1.8.2",
+    "numpy>=1.11.3",
 ]
 
 install_requirements = [

--- a/setup.py
+++ b/setup.py
@@ -35,6 +35,7 @@ with open("README.rst") as readme_file:
 
 setup_requirements = [
     "cython>=0.25.2",
+    "numpy>=1.8.2",
 ]
 
 install_requirements = [


### PR DESCRIPTION
Overrides `setuptools` default `build_ext` command class to ensure NumPy headers are included before the extensions are built, but after setup requirements have already been installed. This way if NumPy was not already installed, we can be sure it has been. So NumPy's headers should be locatable.