### PR TITLE
Implement minmax

### DIFF
--- a/src/cyminmax.pxd
+++ b/src/cyminmax.pxd
@@ -1,5 +1,7 @@
 cimport numpy
 
+import cython
+
 
 ctypedef fused real:
     numpy.uint8_t
@@ -14,6 +16,12 @@ ctypedef fused real:
     numpy.float64_t
 
 
+@cython.binding(False)
+@cython.boundscheck(False)
+@cython.initializedcheck(False)
+@cython.nonecheck(False)
+@cython.overflowcheck(False)
+@cython.wraparound(False)
 cdef inline void cminmax(real[:] arr, real[:] out) nogil:
     cdef real arr_i = arr[0]
     out[:] = arr_i

--- a/src/cyminmax.pxd
+++ b/src/cyminmax.pxd
@@ -1,0 +1,14 @@
+cimport numpy
+
+
+ctypedef fused real:
+    numpy.uint8_t
+    numpy.uint16_t
+    numpy.uint32_t
+    numpy.uint64_t
+    numpy.int8_t
+    numpy.int16_t
+    numpy.int32_t
+    numpy.int64_t
+    numpy.float32_t
+    numpy.float64_t

--- a/src/cyminmax.pxd
+++ b/src/cyminmax.pxd
@@ -12,3 +12,15 @@ ctypedef fused real:
     numpy.int64_t
     numpy.float32_t
     numpy.float64_t
+
+
+cdef inline void cminmax(real[:] arr, real[:] out) nogil:
+    cdef real arr_i = arr[0]
+    out[:] = arr_i
+
+    for i in range(1, arr.shape[0]):
+        arr_i = arr[i]
+        if arr_i < out[0]:
+            out[0] = arr_i
+        elif arr_i > out[1]:
+            out[1] = arr_i

--- a/src/cyminmax.pyx
+++ b/src/cyminmax.pyx
@@ -1,3 +1,58 @@
 cimport cyminmax
 
+import numpy
+cimport numpy
+
 include "version.pxi"
+
+
+def minmax(arr):
+    """
+    Computes the minimum and maximum of an array in one pass.
+
+    This is an optimized version of computing the minimum and maximum
+    by doing both in a single pass.
+
+    Args:
+        arr(array-like):           array to find min and max of.
+
+    Returns:
+        out(numpy.ndarray):        an array with the min and max values.
+    """
+
+    arr = numpy.asanyarray(arr)
+
+    if not arr.size:
+        raise ValueError("zero-size array to reduction operation minmax which has no identity")
+
+    arr = arr.flatten()
+    out = numpy.empty((2,), dtype=arr.dtype)
+
+    if arr.dtype.type is numpy.bool:
+        cyminmax.cminmax[numpy.uint8_t](
+            arr.view(numpy.uint8), out.view(numpy.uint8)
+        )
+    elif arr.dtype.type is numpy.uint8:
+        cyminmax.cminmax[numpy.uint8_t](arr, out)
+    elif arr.dtype.type is numpy.uint16:
+        cyminmax.cminmax[numpy.uint16_t](arr, out)
+    elif arr.dtype.type is numpy.uint32:
+        cyminmax.cminmax[numpy.uint32_t](arr, out)
+    elif arr.dtype.type is numpy.uint64:
+        cyminmax.cminmax[numpy.uint64_t](arr, out)
+    elif arr.dtype.type is numpy.int8:
+        cyminmax.cminmax[numpy.int8_t](arr, out)
+    elif arr.dtype.type is numpy.int16:
+        cyminmax.cminmax[numpy.int16_t](arr, out)
+    elif arr.dtype.type is numpy.int32:
+        cyminmax.cminmax[numpy.int32_t](arr, out)
+    elif arr.dtype.type is numpy.int64:
+        cyminmax.cminmax[numpy.int64_t](arr, out)
+    elif arr.dtype.type is numpy.float32:
+        cyminmax.cminmax[numpy.float32_t](arr, out)
+    elif arr.dtype.type is numpy.float64:
+        cyminmax.cminmax[numpy.float64_t](arr, out)
+    else:
+        raise TypeError("Unsupported type for `arr` of `%s`." % arr.dtype.name)
+
+    return out

--- a/tests/test_cyminmax.py
+++ b/tests/test_cyminmax.py
@@ -5,9 +5,56 @@ from __future__ import absolute_import
 
 import pytest
 
+import numpy
 
-def test_import_toplevel():
+import cyminmax
+
+
+def test_minmax_err():
+    arr = numpy.array(b"boo")
+
+    with pytest.raises(TypeError):
+        cyminmax.minmax(arr)
+
+
+@pytest.mark.parametrize("seed", [
+    0,
+    23,
+    796512,
+])
+@pytest.mark.parametrize("shape", [
+    None,
+    tuple(),
+    (1,),
+    (1, 1),
+    (10),
+    (10, 11),
+])
+@pytest.mark.parametrize("dtype", [
+    numpy.uint8,
+    numpy.uint16,
+    numpy.uint32,
+    numpy.uint64,
+    numpy.int8,
+    numpy.int16,
+    numpy.int32,
+    numpy.int64,
+    numpy.float32,
+    numpy.float64,
+])
+def test_minmax(seed, shape, dtype):
+    numpy.random.seed(seed)
+
+    arr = numpy.random.randint(0, 256, shape)
+
     try:
-        import cyminmax
-    except ImportError:
-        pytest.fail("Unable to import `cyminmax`.")
+        arr = arr.astype(dtype)
+    except AttributeError:
+        arr = dtype(arr)
+
+    expected = numpy.array([arr.min(), arr.max()])
+    result = cyminmax.minmax(arr)
+
+    assert result.dtype == expected.dtype
+    assert result.shape == expected.shape
+    assert (result == expected).all()


### PR DESCRIPTION
Makes a basic C implementation of a `minmax` function, which releases the GIL and leverages many Cython directives to optimize the code path. Then provides access to this function through a Python interface. Supports all NumPy boolean, integral, and floating types. Tests the `minmax` function on a variety of shapes, types, and values when compared to NumPy functions `min` and `max`.