### PR TITLE
Use ravel

### DIFF
--- a/src/cyminmax.pyx
+++ b/src/cyminmax.pyx
@@ -25,7 +25,7 @@ def minmax(arr):
     if not arr.size:
         raise ValueError("zero-size array to reduction operation minmax which has no identity")
 
-    arr = arr.flatten()
+    arr = arr.ravel()
     out = numpy.empty((2,), dtype=arr.dtype)
 
     if arr.dtype.type is numpy.bool:

--- a/src/cyminmax.pyx
+++ b/src/cyminmax.pyx
@@ -25,7 +25,7 @@ def minmax(arr):
     if not arr.size:
         raise ValueError("zero-size array to reduction operation minmax which has no identity")
 
-    arr = arr.ravel()
+    arr = arr.ravel(order="K")
     out = numpy.empty((2,), dtype=arr.dtype)
 
     if arr.dtype.type is numpy.bool:


### PR DESCRIPTION
Instead of using `flatten` (which copies the array) to get a 1-D array, use `ravel` (which tries to return a view). Also encourage `ravel` to return a view for a variety of different array orderings. Should help avoid copying the input array to `minmax` and thus improve performance.