### PR TITLE
Use NumPy's type enum in `if` statements

### DIFF
--- a/src/cyminmax.pxd
+++ b/src/cyminmax.pxd
@@ -8,10 +8,12 @@ ctypedef fused real:
     numpy.npy_ushort
     numpy.npy_uint
     numpy.npy_ulong
+    numpy.npy_ulonglong
     numpy.npy_byte
     numpy.npy_short
     numpy.npy_int
     numpy.npy_long
+    numpy.npy_longlong
     numpy.npy_float
     numpy.npy_double
 

--- a/src/cyminmax.pxd
+++ b/src/cyminmax.pxd
@@ -4,16 +4,16 @@ cimport numpy
 
 ctypedef fused real:
     numpy.npy_bool
-    numpy.uint8_t
-    numpy.uint16_t
-    numpy.uint32_t
-    numpy.uint64_t
-    numpy.int8_t
-    numpy.int16_t
-    numpy.int32_t
-    numpy.int64_t
-    numpy.float32_t
-    numpy.float64_t
+    numpy.npy_ubyte
+    numpy.npy_ushort
+    numpy.npy_uint
+    numpy.npy_ulong
+    numpy.npy_byte
+    numpy.npy_short
+    numpy.npy_int
+    numpy.npy_long
+    numpy.npy_float
+    numpy.npy_double
 
 
 @cython.binding(False)

--- a/src/cyminmax.pyx
+++ b/src/cyminmax.pyx
@@ -28,28 +28,29 @@ def minmax(arr):
     arr = arr.ravel(order="K")
     out = numpy.empty((2,), dtype=arr.dtype)
 
-    if arr.dtype.type is numpy.bool:
+    cdef numpy.NPY_TYPES arr_dtype_num = arr.dtype.num
+    if arr_dtype_num == numpy.NPY_BOOL:
         cyminmax.cminmax[numpy.npy_bool](arr, out)
-    elif arr.dtype.type is numpy.uint8:
-        cyminmax.cminmax[numpy.uint8_t](arr, out)
-    elif arr.dtype.type is numpy.uint16:
-        cyminmax.cminmax[numpy.uint16_t](arr, out)
-    elif arr.dtype.type is numpy.uint32:
-        cyminmax.cminmax[numpy.uint32_t](arr, out)
-    elif arr.dtype.type is numpy.uint64:
-        cyminmax.cminmax[numpy.uint64_t](arr, out)
-    elif arr.dtype.type is numpy.int8:
-        cyminmax.cminmax[numpy.int8_t](arr, out)
-    elif arr.dtype.type is numpy.int16:
-        cyminmax.cminmax[numpy.int16_t](arr, out)
-    elif arr.dtype.type is numpy.int32:
-        cyminmax.cminmax[numpy.int32_t](arr, out)
-    elif arr.dtype.type is numpy.int64:
-        cyminmax.cminmax[numpy.int64_t](arr, out)
-    elif arr.dtype.type is numpy.float32:
-        cyminmax.cminmax[numpy.float32_t](arr, out)
-    elif arr.dtype.type is numpy.float64:
-        cyminmax.cminmax[numpy.float64_t](arr, out)
+    elif arr_dtype_num == numpy.NPY_UBYTE:
+        cyminmax.cminmax[numpy.npy_ubyte](arr, out)
+    elif arr_dtype_num == numpy.NPY_USHORT:
+        cyminmax.cminmax[numpy.npy_ushort](arr, out)
+    elif arr_dtype_num == numpy.NPY_UINT:
+        cyminmax.cminmax[numpy.npy_uint](arr, out)
+    elif arr_dtype_num == numpy.NPY_ULONG:
+        cyminmax.cminmax[numpy.npy_ulong](arr, out)
+    elif arr_dtype_num == numpy.NPY_BYTE:
+        cyminmax.cminmax[numpy.npy_byte](arr, out)
+    elif arr_dtype_num == numpy.NPY_SHORT:
+        cyminmax.cminmax[numpy.npy_short](arr, out)
+    elif arr_dtype_num == numpy.NPY_INT:
+        cyminmax.cminmax[numpy.npy_int](arr, out)
+    elif arr_dtype_num == numpy.NPY_LONG:
+        cyminmax.cminmax[numpy.npy_long](arr, out)
+    elif arr_dtype_num == numpy.NPY_FLOAT:
+        cyminmax.cminmax[numpy.npy_float](arr, out)
+    elif arr_dtype_num == numpy.NPY_DOUBLE:
+        cyminmax.cminmax[numpy.npy_double](arr, out)
     else:
         raise TypeError("Unsupported type for `arr` of `%s`." % arr.dtype.name)
 

--- a/src/cyminmax.pyx
+++ b/src/cyminmax.pyx
@@ -39,6 +39,8 @@ def minmax(arr):
         cyminmax.cminmax[numpy.npy_uint](arr, out)
     elif arr_dtype_num == numpy.NPY_ULONG:
         cyminmax.cminmax[numpy.npy_ulong](arr, out)
+    elif arr_dtype_num == numpy.NPY_ULONGLONG:
+        cyminmax.cminmax[numpy.npy_ulonglong](arr, out)
     elif arr_dtype_num == numpy.NPY_BYTE:
         cyminmax.cminmax[numpy.npy_byte](arr, out)
     elif arr_dtype_num == numpy.NPY_SHORT:
@@ -47,6 +49,8 @@ def minmax(arr):
         cyminmax.cminmax[numpy.npy_int](arr, out)
     elif arr_dtype_num == numpy.NPY_LONG:
         cyminmax.cminmax[numpy.npy_long](arr, out)
+    elif arr_dtype_num == numpy.NPY_LONGLONG:
+        cyminmax.cminmax[numpy.npy_longlong](arr, out)
     elif arr_dtype_num == numpy.NPY_FLOAT:
         cyminmax.cminmax[numpy.npy_float](arr, out)
     elif arr_dtype_num == numpy.NPY_DOUBLE:


### PR DESCRIPTION
Instead of comparing NumPy dtypes directly when determining which `cminmax` type specialization to call, simply compare NumPy's type enum values. This simplifies the checks as they are now just comparisons of integral values where the left hand side is always the same. Given this structure, Cython will try to optimize this down to a `switch` of `case` statements. Further optimizations are therefore possible on the compiler end to allow faster traversal through the type dispatch cases.