### PR TITLE
Use `cimport cython` to get directives to work

### DIFF
--- a/src/cyminmax.pxd
+++ b/src/cyminmax.pxd
@@ -1,6 +1,5 @@
+cimport cython
 cimport numpy
-
-import cython
 
 
 ctypedef fused real:


### PR DESCRIPTION
This was `import cython` before. However it cannot use `import` to get directives to work. Instead it must use `cimport` with `cython`. Thus this changes over to `cimport cython` so that directives will work.