### PR TITLE
Simplify the bool array case

### DIFF
--- a/src/cyminmax.pxd
+++ b/src/cyminmax.pxd
@@ -4,6 +4,7 @@ import cython
 
 
 ctypedef fused real:
+    numpy.npy_bool
     numpy.uint8_t
     numpy.uint16_t
     numpy.uint32_t

--- a/src/cyminmax.pyx
+++ b/src/cyminmax.pyx
@@ -29,7 +29,7 @@ def minmax(arr):
     out = numpy.empty((2,), dtype=arr.dtype)
 
     if arr.dtype.type is numpy.bool:
-        cyminmax.cminmax[numpy.uint8_t](arr, out)
+        cyminmax.cminmax[numpy.npy_bool](arr, out)
     elif arr.dtype.type is numpy.uint8:
         cyminmax.cminmax[numpy.uint8_t](arr, out)
     elif arr.dtype.type is numpy.uint16:

--- a/src/cyminmax.pyx
+++ b/src/cyminmax.pyx
@@ -29,9 +29,7 @@ def minmax(arr):
     out = numpy.empty((2,), dtype=arr.dtype)
 
     if arr.dtype.type is numpy.bool:
-        cyminmax.cminmax[numpy.uint8_t](
-            arr.view(numpy.uint8), out.view(numpy.uint8)
-        )
+        cyminmax.cminmax[numpy.uint8_t](arr, out)
     elif arr.dtype.type is numpy.uint8:
         cyminmax.cminmax[numpy.uint8_t](arr, out)
     elif arr.dtype.type is numpy.uint16:


### PR DESCRIPTION
Tweaks `minmax` and `real` to include NumPy's `npy_bool` type. Thus it is not necessary to take `uint8` views of the arrays or use other tricks. This should cutdown on overhead for the `bool` array case. Further the code becomes clearer with direct usage `bool` related types and values.