### PR TITLE
Drop Python 3.5 on AppVeyor

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -10,14 +10,6 @@ environment:
       CONDA_INSTALL_LOCN: C:\\Miniconda-x64
 
     - TARGET_ARCH: x86
-      CONDA_PY: 3.5
-      CONDA_INSTALL_LOCN: C:\\Miniconda35
-
-    - TARGET_ARCH: x64
-      CONDA_PY: 3.5
-      CONDA_INSTALL_LOCN: C:\\Miniconda35-x64
-
-    - TARGET_ARCH: x86
       CONDA_PY: 3.6
       CONDA_INSTALL_LOCN: C:\\Miniconda36
 


### PR DESCRIPTION
Since the current matrix used here for AppVeyor is taking a bit to run, looking for ways to cutdown on the matrix. Cannot really drop Python 2.7 as VS 2008 is used there and falling out of compatibility with it would be quite painful if we want to get back in sync. Further Python 3.6 is necessary as it is the newest Python version available and uses VS 2015 (so UCRT). Given Python 3.5 and 3.6 are not that different and both use VS 2015 and UCRT, drop the older of the two (Python 3.5). This should lighten up AppVeyor a bit and help it finish more quickly.