### PR TITLE
Use C pointers in `cminmax`

### DIFF
--- a/src/cyminmax.pxd
+++ b/src/cyminmax.pxd
@@ -24,18 +24,21 @@ ctypedef fused real:
 @cython.nonecheck(False)
 @cython.overflowcheck(False)
 @cython.wraparound(False)
-cdef inline void cminmax(real[:] arr, real[:] out) nogil:
-    cdef real arr_i = arr[0]
+cdef inline void cminmax(real[::1] arr, real[::1] out) nogil:
+    cdef size_t arr_size = arr.shape[0]
 
-    cdef real arr_max = arr_i
-    cdef real arr_min = arr_i
+    cdef real* arr_begin = &arr[0]
+    cdef real* arr_end = (arr_begin + arr_size)
 
-    for i in range(1, arr.shape[0]):
-        arr_i = arr[i]
-        if arr_i < arr_min:
-            arr_min = arr_i
-        elif arr_i > arr_max:
-            arr_max = arr_i
+    cdef real* arr_min = &out[0]
+    cdef real* arr_max = (arr_min + 1)
 
-    out[0] = arr_min
-    out[1] = arr_max
+    arr_min[0] = arr_max[0] = arr_begin[0]
+
+    cdef real* arr_pos = arr_begin + 1
+    while arr_pos != arr_end:
+        if arr_pos[0] < arr_min[0]:
+            arr_min[0] = arr_pos[0]
+        elif arr_pos[0] > arr_max[0]:
+            arr_max[0] = arr_pos[0]
+        arr_pos += 1

--- a/src/cyminmax.pxd
+++ b/src/cyminmax.pxd
@@ -26,11 +26,16 @@ ctypedef fused real:
 @cython.wraparound(False)
 cdef inline void cminmax(real[:] arr, real[:] out) nogil:
     cdef real arr_i = arr[0]
-    out[:] = arr_i
+
+    cdef real arr_max = arr_i
+    cdef real arr_min = arr_i
 
     for i in range(1, arr.shape[0]):
         arr_i = arr[i]
-        if arr_i < out[0]:
-            out[0] = arr_i
-        elif arr_i > out[1]:
-            out[1] = arr_i
+        if arr_i < arr_min:
+            arr_min = arr_i
+        elif arr_i > arr_max:
+            arr_max = arr_i
+
+    out[0] = arr_min
+    out[1] = arr_max


### PR DESCRIPTION
Optimizes the Cython implemented C-like `cminmax` further by making use of C pointers instead of `memoryviews`. This avoids some additional checks w.r.t. indexing into the `memoryview` from occurring with the loop (a fixed number still occur outside the loop). Instead simply gets C pointers that bound the input data and one to iterate through the input data. Also gets C pointers for writing in the minimum and maximum values into the `out` array. The resulting Cython generated code is basically the same as handwritten C code for this task. Though keeps the readability and versatility of its Cython form.