### PR TITLE
Test an odd length array

### DIFF
--- a/tests/test_cyminmax.py
+++ b/tests/test_cyminmax.py
@@ -28,6 +28,7 @@ def test_minmax_err():
     (1,),
     (1, 1),
     (10),
+    (11),
     (10, 11),
 ])
 @pytest.mark.parametrize("dtype", [


### PR DESCRIPTION
To make sure that all array cases are better tested, include a non-trivial array with odd length for testing with `minmax`.