### PR TITLE
Optimize comparisons in `cminmax`

### DIFF
--- a/src/cyminmax.pxd
+++ b/src/cyminmax.pxd
@@ -32,16 +32,35 @@ cdef inline void cminmax(real[::1] arr, real[:] out) nogil:
 
     arr_min = arr_max = arr_ptr[0]
 
-    cdef real arr_i
+    cdef real arr_i_0
+    cdef real arr_i_1
 
-    cdef size_t i
-    for i in range(1, arr_size):
-        arr_i = arr_ptr[i]
+    cdef size_t i_0 = 1
+    cdef size_t i_1
+    for i_1 in range(2, arr_size, 2):
+        arr_i_0 = arr_ptr[i_0]
+        arr_i_1 = arr_ptr[i_1]
 
-        if arr_i < arr_min:
-            arr_min = arr_i
-        elif arr_i > arr_max:
-            arr_max = arr_i
+        if arr_i_0 < arr_i_1:
+            if arr_i_0 < arr_min:
+                arr_min = arr_i_0
+            if arr_i_1 > arr_max:
+                arr_max = arr_i_1
+        else:
+            if arr_i_0 > arr_max:
+                arr_max = arr_i_0
+            if arr_i_1 < arr_min:
+                arr_min = arr_i_1
+
+        i_0 += 2
+
+    if i_0 < arr_size:
+        arr_i_0 = arr_ptr[i_0]
+
+        if arr_i_0 < arr_min:
+            arr_min = arr_i_0
+        elif arr_i_0 > arr_max:
+            arr_max = arr_i_0
 
     out[0] = arr_min
     out[1] = arr_max


### PR DESCRIPTION
Cutdown the number of comparisons done in `cminmax` by roughly one quarter. This is done by tracking two neighboring positions and comparing the values of those two positions. From this information, the larger of the two values can be compared to the max only and the smaller of the two values can be compared to the min only. This results in shaving off on extra comparison that either of the two values would go through.