### PR TITLE
Drop `binding` directive from `cminmax`

### DIFF
--- a/src/cyminmax.pxd
+++ b/src/cyminmax.pxd
@@ -18,7 +18,6 @@ ctypedef fused real:
     numpy.npy_double
 
 
-@cython.binding(False)
 @cython.boundscheck(False)
 @cython.initializedcheck(False)
 @cython.nonecheck(False)


### PR DESCRIPTION
As Cython's default is already to set `binding` to `False`, there is not much value in forcing `binding` to `False` for `cminmax`. Further it seems that using this directive on `cminmax` overrides any global directive for `binding`. As a result if `binding` is set to `True` at the global level to allow profiling, this blocks our ability to profile `cminmax` unless we remove the directive from the function as well. Hence we go ahead and drop the `binding` directive from `cminmax` to make profiling easier.