### PR TITLE
Use `arr_ptr` for initial min and max

### DIFF
--- a/src/cyminmax.pxd
+++ b/src/cyminmax.pxd
@@ -30,7 +30,7 @@ cdef inline void cminmax(real[::1] arr, real[:] out) nogil:
     cdef real arr_max
     cdef real arr_min
 
-    arr_min = arr_max = arr[0]
+    arr_min = arr_max = arr_ptr[0]
 
     cdef real arr_i
 


### PR DESCRIPTION
Follow-up to PR ( https://github.com/jakirkham/cyminmax/pull/27 ).

Missed switching from `arr` to `arr_ptr` when setting the initial min and max values when making the move from using the `memoryview` to using a C pointer to the data within the `memoryview`. This fixes that error by ensuring the C pointer is used to set the initial min and max values as well.