### PR TITLE
Drop `source` from `.coveragerc`'s `run` section

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,6 +1,5 @@
 [run]
 branch = True
-source = cyminmax
 plugins = Cython.Coverage
 [report]
 exclude_lines =


### PR DESCRIPTION
As there is not really a proper `source` in our case, just drop it from `.coveragerc`. Not to mention this is an old reference to a package that has already been removed.