### PR TITLE
Require NumPy at install time

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -49,7 +49,7 @@ setup_requirements = [
 ]
 
 install_requirements = [
-    # TODO: put package install requirements here
+    "numpy>=1.11.3",
 ]
 
 test_requirements = [


### PR DESCRIPTION
Not sure how we missed pulling in NumPy at install time, but this fixes that issue.