### PR TITLE
Freshen packaging content

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -9,5 +9,7 @@ recursive-exclude * *.py[co]
 
 recursive-include docs *.rst conf.py Makefile make.bat *.jpg *.png *.gif
 
+include pyproject.toml
+
 include versioneer.py
 include _version.py

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,7 @@
+[build-system]
+requires = [
+    "wheel",
+    "setuptools",
+    "Cython",
+    "numpy",
+]

--- a/setup.py
+++ b/setup.py
@@ -1,9 +1,9 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
+import glob
 import os
 import sys
-from glob import glob
 
 import setuptools
 from setuptools import setup, Extension
@@ -90,7 +90,7 @@ library_dirs = list(filter(
 ))
 
 headers = []
-sources = glob("src/*.pxd") + glob("src/*.pyx")
+sources = glob.glob("src/*.pxd") + glob.glob("src/*.pyx")
 libraries = []
 define_macros = []
 extra_compile_args = []

--- a/setup.py
+++ b/setup.py
@@ -61,7 +61,6 @@ cmdclasses.update(versioneer.get_cmdclass())
 cmdclasses["build_ext"] = NumPyBuildExt
 cmdclasses["test"] = PyTest
 
-
 if not (({"develop", "test"} & set(sys.argv)) or
     any([v.startswith("build") for v in sys.argv]) or
     any([v.startswith("bdist") for v in sys.argv]) or


### PR DESCRIPTION
Refreshes the content in this repo that is package related by taking advantage of [`cookiecutter-cython`]( https://github.com/jakirkham/cookiecutter-cython ). In particular, this used commit ( https://github.com/jakirkham/cookiecutter-cython/commit/de7397f77ba5118c9e5973966f925d2a4af220a7 ), but held off on some changes like the HISTORY file and some formatting w.r.t. the license (both file and metadata).