### PR TITLE
Array data pointer optimizations

### DIFF
--- a/src/cyminmax.pxd
+++ b/src/cyminmax.pxd
@@ -23,10 +23,7 @@ ctypedef fused real:
 @cython.nonecheck(False)
 @cython.overflowcheck(False)
 @cython.wraparound(False)
-cdef inline void cminmax(real[::1] arr, real[:] out) nogil:
-    cdef real* arr_ptr = &arr[0]
-    cdef size_t arr_size = arr.shape[0]
-
+cdef inline void cminmax(real* arr_ptr, size_t arr_size, real[:] out) nogil:
     cdef real arr_max
     cdef real arr_min
 

--- a/src/cyminmax.pyx
+++ b/src/cyminmax.pyx
@@ -31,7 +31,6 @@ def minmax(a):
     if not arr.flags.owndata:
         arr = arr.copy()
 
-    arr = arr.ravel(order="K")
     out = numpy.empty((2,), dtype=arr.dtype)
 
     cdef numpy.NPY_TYPES arr_dtype_num = arr.dtype.num

--- a/src/cyminmax.pyx
+++ b/src/cyminmax.pyx
@@ -36,31 +36,57 @@ def minmax(a):
 
     cdef numpy.NPY_TYPES arr_dtype_num = arr.dtype.num
     if arr_dtype_num == numpy.NPY_BOOL:
-        cyminmax.cminmax[numpy.npy_bool](arr, out)
+        cyminmax.cminmax[numpy.npy_bool](
+            <numpy.npy_bool*>numpy.PyArray_DATA(arr), arr.size, out
+        )
     elif arr_dtype_num == numpy.NPY_UBYTE:
-        cyminmax.cminmax[numpy.npy_ubyte](arr, out)
+        cyminmax.cminmax[numpy.npy_ubyte](
+            <numpy.npy_ubyte*>numpy.PyArray_DATA(arr), arr.size, out
+        )
     elif arr_dtype_num == numpy.NPY_USHORT:
-        cyminmax.cminmax[numpy.npy_ushort](arr, out)
+        cyminmax.cminmax[numpy.npy_ushort](
+            <numpy.npy_ushort*>numpy.PyArray_DATA(arr), arr.size, out
+        )
     elif arr_dtype_num == numpy.NPY_UINT:
-        cyminmax.cminmax[numpy.npy_uint](arr, out)
+        cyminmax.cminmax[numpy.npy_uint](
+            <numpy.npy_uint*>numpy.PyArray_DATA(arr), arr.size, out
+        )
     elif arr_dtype_num == numpy.NPY_ULONG:
-        cyminmax.cminmax[numpy.npy_ulong](arr, out)
+        cyminmax.cminmax[numpy.npy_ulong](
+            <numpy.npy_ulong*>numpy.PyArray_DATA(arr), arr.size, out
+        )
     elif arr_dtype_num == numpy.NPY_ULONGLONG:
-        cyminmax.cminmax[numpy.npy_ulonglong](arr, out)
+        cyminmax.cminmax[numpy.npy_ulonglong](
+            <numpy.npy_ulonglong*>numpy.PyArray_DATA(arr), arr.size, out
+        )
     elif arr_dtype_num == numpy.NPY_BYTE:
-        cyminmax.cminmax[numpy.npy_byte](arr, out)
+        cyminmax.cminmax[numpy.npy_byte](
+            <numpy.npy_byte*>numpy.PyArray_DATA(arr), arr.size, out
+        )
     elif arr_dtype_num == numpy.NPY_SHORT:
-        cyminmax.cminmax[numpy.npy_short](arr, out)
+        cyminmax.cminmax[numpy.npy_short](
+            <numpy.npy_short*>numpy.PyArray_DATA(arr), arr.size, out
+        )
     elif arr_dtype_num == numpy.NPY_INT:
-        cyminmax.cminmax[numpy.npy_int](arr, out)
+        cyminmax.cminmax[numpy.npy_int](
+            <numpy.npy_int*>numpy.PyArray_DATA(arr), arr.size, out
+        )
     elif arr_dtype_num == numpy.NPY_LONG:
-        cyminmax.cminmax[numpy.npy_long](arr, out)
+        cyminmax.cminmax[numpy.npy_long](
+            <numpy.npy_long*>numpy.PyArray_DATA(arr), arr.size, out
+        )
     elif arr_dtype_num == numpy.NPY_LONGLONG:
-        cyminmax.cminmax[numpy.npy_longlong](arr, out)
+        cyminmax.cminmax[numpy.npy_longlong](
+            <numpy.npy_longlong*>numpy.PyArray_DATA(arr), arr.size, out
+        )
     elif arr_dtype_num == numpy.NPY_FLOAT:
-        cyminmax.cminmax[numpy.npy_float](arr, out)
+        cyminmax.cminmax[numpy.npy_float](
+            <numpy.npy_float*>numpy.PyArray_DATA(arr), arr.size, out
+        )
     elif arr_dtype_num == numpy.NPY_DOUBLE:
-        cyminmax.cminmax[numpy.npy_double](arr, out)
+        cyminmax.cminmax[numpy.npy_double](
+            <numpy.npy_double*>numpy.PyArray_DATA(arr), arr.size, out
+        )
     else:
         raise TypeError("Unsupported type for `arr` of `%s`." % arr.dtype.name)
 

--- a/src/cyminmax.pyx
+++ b/src/cyminmax.pyx
@@ -28,6 +28,9 @@ def minmax(a):
             "identity"
         )
 
+    if not arr.flags.owndata:
+        arr = arr.copy()
+
     arr = arr.ravel(order="K")
     out = numpy.empty((2,), dtype=arr.dtype)
 


### PR DESCRIPTION
Instead of working on `memoryview`s of the input array, work directly on the data pointer of the input array. As this avoids some overhead introduced by `ravel`, this goes a bit faster than the `ravel` approach permits. Also make sure that the array we work on owns its data. Without this, the proposed strategy may not work as intended on some views (e.g. `arr = a[::3]`).