### PR TITLE
Make better use of NumPy's C API in minmax

### DIFF
--- a/src/cyminmax.pyx
+++ b/src/cyminmax.pyx
@@ -6,6 +6,9 @@ cimport numpy
 include "version.pxi"
 
 
+numpy.import_array()
+
+
 def minmax(a):
     """
     Computes the minimum and maximum of an array in one pass.
@@ -22,7 +25,7 @@ def minmax(a):
 
     arr = numpy.asanyarray(a)
 
-    if not arr.size:
+    if not numpy.PyArray_SIZE(arr):
         raise ValueError(
             "zero-size array to reduction operation minmax which has no "
             "identity"

--- a/src/cyminmax.pyx
+++ b/src/cyminmax.pyx
@@ -25,7 +25,9 @@ def minmax(a):
 
     arr = numpy.asanyarray(a)
 
-    if not numpy.PyArray_SIZE(arr):
+    cdef size_t arr_size = numpy.PyArray_SIZE(arr)
+
+    if not arr_size:
         raise ValueError(
             "zero-size array to reduction operation minmax which has no "
             "identity"
@@ -41,55 +43,55 @@ def minmax(a):
     cdef numpy.NPY_TYPES arr_dtype_num = arr.dtype.num
     if arr_dtype_num == numpy.NPY_BOOL:
         cyminmax.cminmax[numpy.npy_bool](
-            <numpy.npy_bool*>numpy.PyArray_DATA(arr), arr.size, out
+            <numpy.npy_bool*>numpy.PyArray_DATA(arr), arr_size, out
         )
     elif arr_dtype_num == numpy.NPY_UBYTE:
         cyminmax.cminmax[numpy.npy_ubyte](
-            <numpy.npy_ubyte*>numpy.PyArray_DATA(arr), arr.size, out
+            <numpy.npy_ubyte*>numpy.PyArray_DATA(arr), arr_size, out
         )
     elif arr_dtype_num == numpy.NPY_USHORT:
         cyminmax.cminmax[numpy.npy_ushort](
-            <numpy.npy_ushort*>numpy.PyArray_DATA(arr), arr.size, out
+            <numpy.npy_ushort*>numpy.PyArray_DATA(arr), arr_size, out
         )
     elif arr_dtype_num == numpy.NPY_UINT:
         cyminmax.cminmax[numpy.npy_uint](
-            <numpy.npy_uint*>numpy.PyArray_DATA(arr), arr.size, out
+            <numpy.npy_uint*>numpy.PyArray_DATA(arr), arr_size, out
         )
     elif arr_dtype_num == numpy.NPY_ULONG:
         cyminmax.cminmax[numpy.npy_ulong](
-            <numpy.npy_ulong*>numpy.PyArray_DATA(arr), arr.size, out
+            <numpy.npy_ulong*>numpy.PyArray_DATA(arr), arr_size, out
         )
     elif arr_dtype_num == numpy.NPY_ULONGLONG:
         cyminmax.cminmax[numpy.npy_ulonglong](
-            <numpy.npy_ulonglong*>numpy.PyArray_DATA(arr), arr.size, out
+            <numpy.npy_ulonglong*>numpy.PyArray_DATA(arr), arr_size, out
         )
     elif arr_dtype_num == numpy.NPY_BYTE:
         cyminmax.cminmax[numpy.npy_byte](
-            <numpy.npy_byte*>numpy.PyArray_DATA(arr), arr.size, out
+            <numpy.npy_byte*>numpy.PyArray_DATA(arr), arr_size, out
         )
     elif arr_dtype_num == numpy.NPY_SHORT:
         cyminmax.cminmax[numpy.npy_short](
-            <numpy.npy_short*>numpy.PyArray_DATA(arr), arr.size, out
+            <numpy.npy_short*>numpy.PyArray_DATA(arr), arr_size, out
         )
     elif arr_dtype_num == numpy.NPY_INT:
         cyminmax.cminmax[numpy.npy_int](
-            <numpy.npy_int*>numpy.PyArray_DATA(arr), arr.size, out
+            <numpy.npy_int*>numpy.PyArray_DATA(arr), arr_size, out
         )
     elif arr_dtype_num == numpy.NPY_LONG:
         cyminmax.cminmax[numpy.npy_long](
-            <numpy.npy_long*>numpy.PyArray_DATA(arr), arr.size, out
+            <numpy.npy_long*>numpy.PyArray_DATA(arr), arr_size, out
         )
     elif arr_dtype_num == numpy.NPY_LONGLONG:
         cyminmax.cminmax[numpy.npy_longlong](
-            <numpy.npy_longlong*>numpy.PyArray_DATA(arr), arr.size, out
+            <numpy.npy_longlong*>numpy.PyArray_DATA(arr), arr_size, out
         )
     elif arr_dtype_num == numpy.NPY_FLOAT:
         cyminmax.cminmax[numpy.npy_float](
-            <numpy.npy_float*>numpy.PyArray_DATA(arr), arr.size, out
+            <numpy.npy_float*>numpy.PyArray_DATA(arr), arr_size, out
         )
     elif arr_dtype_num == numpy.NPY_DOUBLE:
         cyminmax.cminmax[numpy.npy_double](
-            <numpy.npy_double*>numpy.PyArray_DATA(arr), arr.size, out
+            <numpy.npy_double*>numpy.PyArray_DATA(arr), arr_size, out
         )
     else:
         raise TypeError("Unsupported type for `arr` of `%s`." % arr.dtype.name)

--- a/src/cyminmax.pyx
+++ b/src/cyminmax.pyx
@@ -41,60 +41,62 @@ def minmax(a):
         arr = arr.copy()
         arr_ownsdata = True
 
+    cdef void* arr_data = numpy.PyArray_DATA(arr)
+
     cdef numpy.npy_intp out_shape = 2
     out = numpy.PyArray_EMPTY(1, &out_shape, arr_dtype_num, 0)
 
     if arr_dtype_num == numpy.NPY_BOOL:
         cyminmax.cminmax[numpy.npy_bool](
-            <numpy.npy_bool*>numpy.PyArray_DATA(arr), arr_size, out
+            <numpy.npy_bool*>arr_data, arr_size, out
         )
     elif arr_dtype_num == numpy.NPY_UBYTE:
         cyminmax.cminmax[numpy.npy_ubyte](
-            <numpy.npy_ubyte*>numpy.PyArray_DATA(arr), arr_size, out
+            <numpy.npy_ubyte*>arr_data, arr_size, out
         )
     elif arr_dtype_num == numpy.NPY_USHORT:
         cyminmax.cminmax[numpy.npy_ushort](
-            <numpy.npy_ushort*>numpy.PyArray_DATA(arr), arr_size, out
+            <numpy.npy_ushort*>arr_data, arr_size, out
         )
     elif arr_dtype_num == numpy.NPY_UINT:
         cyminmax.cminmax[numpy.npy_uint](
-            <numpy.npy_uint*>numpy.PyArray_DATA(arr), arr_size, out
+            <numpy.npy_uint*>arr_data, arr_size, out
         )
     elif arr_dtype_num == numpy.NPY_ULONG:
         cyminmax.cminmax[numpy.npy_ulong](
-            <numpy.npy_ulong*>numpy.PyArray_DATA(arr), arr_size, out
+            <numpy.npy_ulong*>arr_data, arr_size, out
         )
     elif arr_dtype_num == numpy.NPY_ULONGLONG:
         cyminmax.cminmax[numpy.npy_ulonglong](
-            <numpy.npy_ulonglong*>numpy.PyArray_DATA(arr), arr_size, out
+            <numpy.npy_ulonglong*>arr_data, arr_size, out
         )
     elif arr_dtype_num == numpy.NPY_BYTE:
         cyminmax.cminmax[numpy.npy_byte](
-            <numpy.npy_byte*>numpy.PyArray_DATA(arr), arr_size, out
+            <numpy.npy_byte*>arr_data, arr_size, out
         )
     elif arr_dtype_num == numpy.NPY_SHORT:
         cyminmax.cminmax[numpy.npy_short](
-            <numpy.npy_short*>numpy.PyArray_DATA(arr), arr_size, out
+            <numpy.npy_short*>arr_data, arr_size, out
         )
     elif arr_dtype_num == numpy.NPY_INT:
         cyminmax.cminmax[numpy.npy_int](
-            <numpy.npy_int*>numpy.PyArray_DATA(arr), arr_size, out
+            <numpy.npy_int*>arr_data, arr_size, out
         )
     elif arr_dtype_num == numpy.NPY_LONG:
         cyminmax.cminmax[numpy.npy_long](
-            <numpy.npy_long*>numpy.PyArray_DATA(arr), arr_size, out
+            <numpy.npy_long*>arr_data, arr_size, out
         )
     elif arr_dtype_num == numpy.NPY_LONGLONG:
         cyminmax.cminmax[numpy.npy_longlong](
-            <numpy.npy_longlong*>numpy.PyArray_DATA(arr), arr_size, out
+            <numpy.npy_longlong*>arr_data, arr_size, out
         )
     elif arr_dtype_num == numpy.NPY_FLOAT:
         cyminmax.cminmax[numpy.npy_float](
-            <numpy.npy_float*>numpy.PyArray_DATA(arr), arr_size, out
+            <numpy.npy_float*>arr_data, arr_size, out
         )
     elif arr_dtype_num == numpy.NPY_DOUBLE:
         cyminmax.cminmax[numpy.npy_double](
-            <numpy.npy_double*>numpy.PyArray_DATA(arr), arr_size, out
+            <numpy.npy_double*>arr_data, arr_size, out
         )
     else:
         raise TypeError("Unsupported type for `arr` of `%s`." % arr.dtype.name)

--- a/src/cyminmax.pyx
+++ b/src/cyminmax.pyx
@@ -25,6 +25,7 @@ def minmax(a):
 
     arr = numpy.asanyarray(a)
 
+    cdef numpy.dtype arr_dtype = arr.dtype
     cdef size_t arr_size = numpy.PyArray_SIZE(arr)
 
     if not arr_size:
@@ -38,9 +39,9 @@ def minmax(a):
         arr = arr.copy()
         arr_ownsdata = True
 
-    out = numpy.empty((2,), dtype=arr.dtype)
+    out = numpy.empty((2,), dtype=arr_dtype)
 
-    cdef numpy.NPY_TYPES arr_dtype_num = arr.dtype.num
+    cdef numpy.NPY_TYPES arr_dtype_num = arr_dtype.num
     if arr_dtype_num == numpy.NPY_BOOL:
         cyminmax.cminmax[numpy.npy_bool](
             <numpy.npy_bool*>numpy.PyArray_DATA(arr), arr_size, out

--- a/src/cyminmax.pyx
+++ b/src/cyminmax.pyx
@@ -39,7 +39,8 @@ def minmax(a):
         arr = arr.copy()
         arr_ownsdata = True
 
-    out = numpy.empty((2,), dtype=arr_dtype)
+    cdef numpy.npy_intp out_shape = 2
+    out = numpy.PyArray_EMPTY(1, &out_shape, arr_dtype.num, 0)
 
     cdef numpy.NPY_TYPES arr_dtype_num = arr_dtype.num
     if arr_dtype_num == numpy.NPY_BOOL:

--- a/src/cyminmax.pyx
+++ b/src/cyminmax.pyx
@@ -28,8 +28,10 @@ def minmax(a):
             "identity"
         )
 
-    if not arr.flags.owndata:
+    cdef bint arr_ownsdata = numpy.PyArray_CHKFLAGS(arr, numpy.NPY_OWNDATA)
+    if not arr_ownsdata:
         arr = arr.copy()
+        arr_ownsdata = True
 
     out = numpy.empty((2,), dtype=arr.dtype)
 

--- a/src/cyminmax.pyx
+++ b/src/cyminmax.pyx
@@ -25,7 +25,9 @@ def minmax(a):
 
     arr = numpy.asanyarray(a)
 
-    cdef numpy.dtype arr_dtype = arr.dtype
+    cdef numpy.NPY_TYPES arr_dtype_num = <numpy.NPY_TYPES>numpy.PyArray_TYPE(
+        arr
+    )
     cdef size_t arr_size = numpy.PyArray_SIZE(arr)
 
     if not arr_size:
@@ -40,9 +42,8 @@ def minmax(a):
         arr_ownsdata = True
 
     cdef numpy.npy_intp out_shape = 2
-    out = numpy.PyArray_EMPTY(1, &out_shape, arr_dtype.num, 0)
+    out = numpy.PyArray_EMPTY(1, &out_shape, arr_dtype_num, 0)
 
-    cdef numpy.NPY_TYPES arr_dtype_num = arr_dtype.num
     if arr_dtype_num == numpy.NPY_BOOL:
         cyminmax.cminmax[numpy.npy_bool](
             <numpy.npy_bool*>numpy.PyArray_DATA(arr), arr_size, out


### PR DESCRIPTION
This leverages NumPy's C API throughout `minmax` to cutdown on overhead from using NumPy's Python API previously. Helps make things a bit faster when running `minmax`.