### PR TITLE
More NumPy's C API usage

### DIFF
--- a/src/cyminmax.pyx
+++ b/src/cyminmax.pyx
@@ -41,7 +41,7 @@ def minmax(a):
 
     cdef bint arr_ownsdata = numpy.PyArray_CHKFLAGS(arr, numpy.NPY_OWNDATA)
     if not arr_ownsdata:
-        arr = arr.copy()
+        arr = numpy.PyArray_Copy(arr)
         arr_ownsdata = True
 
     cdef void* arr_data = numpy.PyArray_DATA(arr)

--- a/src/cyminmax.pyx
+++ b/src/cyminmax.pyx
@@ -1,5 +1,7 @@
 cimport cyminmax
 
+cimport cpython
+
 import numpy
 cimport numpy
 
@@ -23,7 +25,8 @@ def minmax(a):
         out(numpy.ndarray):        an array with the min and max values.
     """
 
-    arr = numpy.asanyarray(a)
+    cpython.Py_INCREF(a)
+    arr = numpy.PyArray_EnsureAnyArray(a)
 
     cdef numpy.NPY_TYPES arr_dtype_num = <numpy.NPY_TYPES>numpy.PyArray_TYPE(
         arr

--- a/src/cyminmax.pyx
+++ b/src/cyminmax.pyx
@@ -1,8 +1,6 @@
 cimport cyminmax
 
 cimport cpython
-
-import numpy
 cimport numpy
 
 include "version.pxi"


### PR DESCRIPTION
Follow-up to PR ( https://github.com/jakirkham/cyminmax/pull/39 ).

Uses a few more tricks from NumPy's C-API to eliminate any direct usage of NumPy's Python API. Removes a little bit more overhead from `minmax` as a result.