### PR TITLE
Reverts "Optimize comparisons in `cminmax`"

### DIFF
--- a/src/cyminmax.pxd
+++ b/src/cyminmax.pxd
@@ -29,35 +29,16 @@ cdef inline void cminmax(real* arr_ptr, size_t arr_size, real[:] out) nogil:
 
     arr_min = arr_max = arr_ptr[0]
 
-    cdef real arr_i_0
-    cdef real arr_i_1
+    cdef real arr_i
 
-    cdef size_t i_0 = 1
-    cdef size_t i_1
-    for i_1 in range(2, arr_size, 2):
-        arr_i_0 = arr_ptr[i_0]
-        arr_i_1 = arr_ptr[i_1]
+    cdef size_t i
+    for i in range(1, arr_size):
+        arr_i = arr_ptr[i]
 
-        if arr_i_0 < arr_i_1:
-            if arr_i_0 < arr_min:
-                arr_min = arr_i_0
-            if arr_i_1 > arr_max:
-                arr_max = arr_i_1
-        else:
-            if arr_i_0 > arr_max:
-                arr_max = arr_i_0
-            if arr_i_1 < arr_min:
-                arr_min = arr_i_1
-
-        i_0 += 2
-
-    if i_0 < arr_size:
-        arr_i_0 = arr_ptr[i_0]
-
-        if arr_i_0 < arr_min:
-            arr_min = arr_i_0
-        elif arr_i_0 > arr_max:
-            arr_max = arr_i_0
+        if arr_i < arr_min:
+            arr_min = arr_i
+        elif arr_i > arr_max:
+            arr_max = arr_i
 
     out[0] = arr_min
     out[1] = arr_max


### PR DESCRIPTION
This reverts commit cff3082bb3d896c0b7029b74d855807ad89c6365, reversing changes made to 05697fe55572bd7bf2d0965b22386c3dabc8150c.

While this strategy technically cuts down on the number of comparisons done to get the minimum and maximum values by working with pairs, it appears this still ends up being slower than just doing the simple check per value in the array. Thus this reverts the pairwise check to return to the single value check.